### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -10,6 +10,7 @@
     "express-session": "^1.18.2",
     "helmet": "^8.1.0",
     "passport": "^0.7.0",
-    "dotenv": "^17.2.1"
+    "dotenv": "^17.2.1",
+    "express-rate-limit": "^8.0.1"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/oldmagic/passport-steam/security/code-scanning/2](https://github.com/oldmagic/passport-steam/security/code-scanning/2)

The best practice is to add request rate limiting middleware specifically to the `/auth/steam/return` route (or potentially to all authentication routes). In Express, this is cleanly done using a package like `express-rate-limit`. Since `express-rate-limit` is a well-known, widely used package with built-in TypeScript and CommonJS support, it can be imported and configured at the top of the file. A sensible rate (e.g., 5 attempts per minute per IP for this endpoint) can be set. Only the relevant import, limiter configuration, and `.use()` or per-route middleware need to be added; existing route logic should not be changed.

**Specific changes:**  
- Import `express-rate-limit` at the top of `examples/express/server.js`.
- Define a rate limiter instance with suitable settings for the `/auth/steam/return` route.
- Insert the rate limiter as middleware (e.g., `app.get('/auth/steam/return', limiter, ...)`).
- No changes to the internal route handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
