### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/oldmagic/passport-steam/security/code-scanning/1](https://github.com/oldmagic/passport-steam/security/code-scanning/1)

The best way to fix this issue is to explicitly add a `permissions` block with least-privilege settings to the workflow. Since no step in the workflow needs to write to the repository or perform privileged operations (like modifying issues or pull requests), setting `permissions: contents: read` at the workflow root is sufficient and safest. This change should be placed directly below the `name: CI` line (line 1) and above the `on:` block (line 3) to make it apply globally to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
